### PR TITLE
Refactor PDF generation in ScheduleController

### DIFF
--- a/Controllers/BillController.cs
+++ b/Controllers/BillController.cs
@@ -936,6 +936,14 @@ namespace VaccineAPI.Controllers
 
                     foreach (var row in reportData)
                     {
+                        if (
+                            row.VaccinesDone == 0
+                            && row.StockPurchased == 0
+                            && row.StockAdjusted == 0
+                        )
+                        {
+                            continue;
+                        }
                         table.AddCell(
                             new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont))
                             {
@@ -943,7 +951,7 @@ namespace VaccineAPI.Controllers
                             }
                         );
                         table.AddCell(
-                            new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont))
+                            new PdfPCell(new Phrase((row.Inventory+row.VaccinesDone).ToString(), normalFont))
                             {
                                 HorizontalAlignment = Element.ALIGN_CENTER,
                             }
@@ -971,7 +979,6 @@ namespace VaccineAPI.Controllers
                                 new Phrase(
                                     (
                                         row.Inventory
-                                        + row.VaccinesDone
                                         + row.StockPurchased
                                         + row.StockAdjusted
                                     ).ToString(),

--- a/Controllers/BillController.cs
+++ b/Controllers/BillController.cs
@@ -693,7 +693,6 @@ namespace VaccineAPI.Controllers
                 var parsedFromDate = DateTime.Parse(fromDate);
                 var parsedToDate = DateTime.Parse(toDate);
 
-                // Fetch clinic details
                 var clinic = _db
                     .Clinics.Include(c => c.Doctor)
                     .FirstOrDefault(c => c.Id == clinicId);
@@ -702,47 +701,32 @@ namespace VaccineAPI.Controllers
                     return NotFound("Clinic not found.");
                 }
 
-                // Fetch brand details
                 var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
                 if (brand == null)
                 {
                     return NotFound("Brand not found.");
                 }
 
-                // Clinic details with null checks
                 var doctorName = clinic.Doctor?.DisplayName ?? "Unknown Doctor";
                 var additionalInfo = clinic.Doctor?.AdditionalInfo ?? "No additional info";
                 var clinicName = clinic.Name ?? "Unknown Clinic";
                 var monogramImage = clinic.MonogramImage ?? "default-monogram.png";
                 var address = clinic.Address ?? "Unknown Address";
                 var phoneNumber = clinic.PhoneNumber ?? "Unknown Phone Number";
-
-                //          var parsedFromDate = DateTime.Parse(fromDate).Date;
-                // var parsedToDate = DateTime.Parse(toDate).Date;
                 var today = DateTime.Today;
 
-                // Get brand
-                // var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
-                if (brand == null)
-                    return NotFound("Brand not found.");
-
-                // Get today's inventory
                 var brandAmount = _db.BrandAmounts.FirstOrDefault(b =>
-                    b.BrandId == brandId && b.ClinicId == clinicId
-                );
-
+                    b.BrandId == brandId && b.ClinicId == clinicId);
                 if (brandAmount == null)
                     return NotFound("Brand amount not found.");
 
                 int todaysInventory = brandAmount.Count;
 
-                // Get all schedules from fromDate to today
                 var schedules = _db
                     .Schedules.Where(s =>
                         s.BrandId == brandId
                         && s.GivenDate >= parsedFromDate
-                        && s.GivenDate <= today
-                    )
+                        && s.GivenDate <= today)
                     .ToList();
 
                 var stockPurchases = _db
@@ -820,7 +804,6 @@ namespace VaccineAPI.Controllers
                         + totalFutureVaccines
                         + cumulativeStockPurchased
                         + cumulativeStockAdjusted;
-                    // New logic for stock in hand (up to current date)
                     int cumulativeVaccinesDone = schedules.Where(s => s.GivenDate <= date).Count();
 
                     int cumulativePurchased = stockPurchases
@@ -830,8 +813,6 @@ namespace VaccineAPI.Controllers
                     int cumulativeAdjusted = stockAdjustments
                         .Where(kvp => kvp.Key <= date)
                         .Sum(kvp => kvp.Value);
-
-                    // int stockInHand = todaysInventory - cumulativeVaccinesDone + cumulativePurchased + cumulativeAdjusted;
 
                     reportData.Add(
                         (
@@ -845,63 +826,6 @@ namespace VaccineAPI.Controllers
                     );
                 }
 
-                // Generate list of dates
-                // var allDates = Enumerable
-                //     .Range(0, (parsedToDate - parsedFromDate).Days + 1)
-                //     .Select(offset => parsedFromDate.AddDays(offset))
-                //     .ToList();
-
-                // // Fetch report data
-                // var reportData = (
-                //     from date in allDates
-                //     join bill in _db.Bills on date.Date equals bill.BillDate.Date into billGroup
-                //     from bill in billGroup.DefaultIfEmpty()
-                //     join stock in _db.Stocks on bill.Id equals stock.BillId into stockGroup
-                //     from stock in stockGroup.DefaultIfEmpty()
-                //     join brandAmount in _db.BrandAmounts
-                //         on new { BrandId = stock?.BrandId ?? 0, ClinicId = clinicId } equals new
-                //         {
-                //             brandAmount.BrandId,
-                //             brandAmount.ClinicId,
-                //         }
-                //         into brandAmountGroup
-                //     from brandAmount in brandAmountGroup.DefaultIfEmpty()
-                //     join adjust in _db.AdjustStocks
-                //         on stock?.BrandId ?? 0 equals adjust.BrandId
-                //         into adjustGroup
-                //     from adjust in adjustGroup.DefaultIfEmpty()
-                //     join schedule in _db.Schedules
-                //         on stock?.BrandId ?? 0 equals schedule.BrandId
-                //         into scheduleGroup
-                //     from schedule in scheduleGroup.DefaultIfEmpty()
-                //     where stock == null || stock.BrandId == brandId
-                //     group new
-                //     {
-                //         date,
-                //         stock,
-                //         adjust,
-                //         schedule,
-                //         brandAmount,
-                //     } by date.Date into grouped
-                //     select new
-                //     {
-                //         Date = grouped.Key,
-                //         OpeningStock = grouped.Sum(g => g.brandAmount?.Count ?? 0), // Default to 0 if no data
-                //         Sold = grouped.Sum(g => g.schedule != null ? 1 : 0), // Default to 0 if no data
-                //         Adjust = grouped.Sum(g => g.adjust?.Adjustment ?? 0), // Default to 0 if no data
-                //         Inventory = grouped.Sum(g => g.brandAmount?.Count ?? 0)
-                //             - grouped.Sum(g => g.schedule != null ? 1 : 0)
-                //             + grouped.Sum(g => g.adjust?.Adjustment ?? 0),
-                //     }
-                // ).OrderBy(r => r.Date).ToList();
-
-                // if (!reportData.Any())
-                // {
-                //     return NotFound(
-                //         "No data found for the specified clinic, brand, and date range."
-                //     );
-                // }
-
                 using (MemoryStream ms = new MemoryStream())
                 {
                     Document document = new Document(PageSize.A4, 25, 25, 30, 30);
@@ -909,7 +833,6 @@ namespace VaccineAPI.Controllers
                     writer.PageEvent = new PdfFooter(); // Custom footer if you have one
                     document.Open();
 
-                    // Create upper header with clinic info
                     PdfPTable upperTable = new PdfPTable(2);
                     float[] upperTableWidths = new float[] { 350f, 160f };
                     upperTable.HorizontalAlignment = 0;
@@ -960,8 +883,6 @@ namespace VaccineAPI.Controllers
 
                     upperTable.AddCell(imageCell);
                     document.Add(upperTable);
-
-                    // Titles
                     Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
                     Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 9);
 
@@ -995,10 +916,10 @@ namespace VaccineAPI.Controllers
                     string[] headers =
                     {
                         "Date",
-                        "Inventory",
-                        "Vaccines Done",
-                        "Stock Purchased",
-                        "Stock Adjusted",
+                        "Opening Stock",
+                        "Sold",
+                        "Purchased",
+                        "Adjusted",
                         "Stock In Hand",
                     };
                     foreach (var header in headers)
@@ -1062,106 +983,8 @@ namespace VaccineAPI.Controllers
                             }
                         );
                     }
-
                     document.Add(table);
                     document.Close();
-
-                    // // Report Table
-                    // PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
-                    // table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
-
-                    // string[] headers = { "Date", "Opening Stock", "Sold", "Adjust", "Inventory" };
-                    // foreach (var header in headers)
-                    // {
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(header, headerFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //             Padding = 6,
-                    //             BackgroundColor = BaseColor.LightGray,
-                    //         }
-                    //     );
-                    // }
-
-                    // foreach (var row in reportData)
-                    // {
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         }
-                    //     );
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(row.OpeningStock.ToString(), normalFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         }
-                    //     );
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(row.Sold.ToString(), normalFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         }
-                    //     );
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(row.Adjust.ToString(), normalFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         }
-                    //     );
-                    //     table.AddCell(
-                    //         new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont))
-                    //         {
-                    //             HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         }
-                    //     );
-                    // }
-
-                    // // Summary Row
-                    // table.AddCell(
-                    //     new PdfPCell(new Phrase("Total", headerFont))
-                    //     {
-                    //         HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         BackgroundColor = BaseColor.LightGray,
-                    //     }
-                    // );
-                    // table.AddCell(
-                    //     new PdfPCell(
-                    //         new Phrase(reportData.Sum(r => r.OpeningStock).ToString(), headerFont)
-                    //     )
-                    //     {
-                    //         HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         BackgroundColor = BaseColor.LightGray,
-                    //     }
-                    // );
-                    // table.AddCell(
-                    //     new PdfPCell(new Phrase(reportData.Sum(r => r.Sold).ToString(), headerFont))
-                    //     {
-                    //         HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         BackgroundColor = BaseColor.LightGray,
-                    //     }
-                    // );
-                    // table.AddCell(
-                    //     new PdfPCell(
-                    //         new Phrase(reportData.Sum(r => r.Adjust).ToString(), headerFont)
-                    //     )
-                    //     {
-                    //         HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         BackgroundColor = BaseColor.LightGray,
-                    //     }
-                    // );
-                    // table.AddCell(
-                    //     new PdfPCell(
-                    //         new Phrase(reportData.Sum(r => r.Inventory).ToString(), headerFont)
-                    //     )
-                    //     {
-                    //         HorizontalAlignment = Element.ALIGN_CENTER,
-                    //         BackgroundColor = BaseColor.LightGray,
-                    //     }
-                    // );
-
-                    // document.Add(table);
-                    // document.Close();
 
                     return File(
                         ms.ToArray(),
@@ -1172,7 +995,6 @@ namespace VaccineAPI.Controllers
             }
             catch (Exception ex)
             {
-                // Optional: add logging here
                 return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
             }
         }

--- a/Controllers/BillController.cs
+++ b/Controllers/BillController.cs
@@ -5,6 +5,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using VaccineAPI.ModelDTO;
 using VaccineAPI.Models;
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using AutoMapper;
+using iTextSharp.text;
+using iTextSharp.text.pdf;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
 
 namespace VaccineAPI.Controllers
 {
@@ -14,11 +22,13 @@ namespace VaccineAPI.Controllers
     {
         private readonly Context _db;
         private readonly IMapper _mapper;
+        private readonly IWebHostEnvironment _host;
 
-        public BillController(Context context, IMapper mapper)
+        public BillController(Context context, IMapper mapper, IWebHostEnvironment host)
         {
             _db = context;
             _mapper = mapper;
+            _host = host;
         }
 
         [HttpGet]
@@ -270,5 +280,1963 @@ namespace VaccineAPI.Controllers
                 return StatusCode(500, new { message = $"An error occurred: {ex.Message}" });
             }
         }
+
+        // [HttpGet("custom-report-pdf/{entityId}")]
+        // public IActionResult GenerateCustomReportPdf(
+        //     long entityId,
+        //     [FromQuery] string fromDate,
+        //     [FromQuery] string toDate
+        // )
+        // {
+        //     try
+        //     {
+        //         var parsedFromDate = DateTime.Parse(fromDate);
+        //         var parsedToDate = DateTime.Parse(toDate);
+
+        //         // Fetch data for the custom report
+        //         var entity = _db.Entities.FirstOrDefault(e => e.Id == entityId);
+        //         if (entity == null)
+        //         {
+        //             return NotFound("Entity not found.");
+        //         }
+
+        //         var reportData = _db
+        //             .CustomTable.Where(r =>
+        //                 r.EntityId == entityId && r.Date >= parsedFromDate && r.Date <= parsedToDate
+        //             )
+        //             .Select(r => new
+        //             {
+        //                 r.Column1,
+        //                 r.Column2,
+        //                 r.Column3,
+        //                 r.Column4,
+        //                 r.Column5,
+        //                 r.Column6,
+        //                 r.Date,
+        //             })
+        //             .OrderBy(r => r.Date)
+        //             .ToList();
+
+        //         if (!reportData.Any())
+        //         {
+        //             return NotFound("No data found for the specified entity and date range.");
+        //         }
+
+        //         using (MemoryStream ms = new MemoryStream())
+        //         {
+        //             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+        //             PdfWriter writer = PdfWriter.GetInstance(document, ms);
+        //             writer.PageEvent = new PdfFooter(); // Reuse the PdfFooter class for the footer
+        //             document.Open();
+
+        //             // Add header information
+        //             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+        //             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 9);
+
+        //             Paragraph title = new Paragraph(
+        //                 $"Custom Report for Entity: {entity.Name}",
+        //                 headerFont
+        //             );
+        //             title.Alignment = Element.ALIGN_CENTER;
+        //             title.SpacingAfter = 10f;
+        //             document.Add(title);
+
+        //             Paragraph dateRange = new Paragraph(
+        //                 $"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}",
+        //                 normalFont
+        //             );
+        //             dateRange.Alignment = Element.ALIGN_CENTER;
+        //             dateRange.SpacingAfter = 20f;
+        //             document.Add(dateRange);
+
+        //             // Create the table
+        //             PdfPTable table = new PdfPTable(6);
+        //             table.WidthPercentage = 100;
+        //             table.SetWidths(new float[] { 1.5f, 2f, 2f, 2f, 1.5f, 2f });
+
+        //             // Add table headers
+        //             string[] headers =
+        //             {
+        //                 "Column 1",
+        //                 "Column 2",
+        //                 "Column 3",
+        //                 "Column 4",
+        //                 "Column 5",
+        //                 "Column 6",
+        //             };
+        //             foreach (string header in headers)
+        //             {
+        //                 var cell = new PdfPCell(new Phrase(header, headerFont))
+        //                 {
+        //                     HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     Padding = 6,
+        //                     BackgroundColor = BaseColor.LightGray,
+        //                 };
+        //                 table.AddCell(cell);
+        //             }
+
+        //             // Add table data
+        //             foreach (var row in reportData)
+        //             {
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column1.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column2.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column3.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column4.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column5.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Column6.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_LEFT,
+        //                     }
+        //                 );
+        //             }
+
+        //             document.Add(table);
+
+        //             // Add summary (optional)
+        //             Paragraph summary = new Paragraph(
+        //                 $"\nTotal Records: {reportData.Count}",
+        //                 headerFont
+        //             );
+        //             summary.SpacingBefore = 20f;
+        //             document.Add(summary);
+
+        //             document.Close();
+        //             return File(
+        //                 ms.ToArray(),
+        //                 "application/pdf",
+        //                 $"CustomReport_{entityId}_{parsedFromDate:yyyyMMdd}_{parsedToDate:yyyyMMdd}.pdf"
+        //             );
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         return BadRequest($"Error generating PDF: {ex.Message}");
+        //     }
+        // }
+
+        // public class PdfFooter : PdfPageEventHelper
+        // {
+        //     public override void OnEndPage(PdfWriter writer, Document document)
+        //     {
+        //         string footerText = $"Generated on: {DateTime.Now:yyyy-MM-dd HH:mm:ss}";
+        //         Font footerFont = FontFactory.GetFont(
+        //             FontFactory.HELVETICA,
+        //             8,
+        //             Font.NORMAL,
+        //             BaseColor.Gray
+        //         );
+
+        //         PdfPTable footerTable = new PdfPTable(1);
+        //         footerTable.TotalWidth =
+        //             document.PageSize.Width - document.LeftMargin - document.RightMargin;
+        //         footerTable.DefaultCell.Border = Rectangle.NO_BORDER;
+        //         footerTable.DefaultCell.HorizontalAlignment = Element.ALIGN_CENTER;
+        //         footerTable.AddCell(new Phrase(footerText, footerFont));
+
+        //         footerTable.WriteSelectedRows(
+        //             0,
+        //             -1,
+        //             document.LeftMargin,
+        //             document.BottomMargin - 10,
+        //             writer.DirectContent
+        //         );
+        //     }
+        // }
+
+        public class PdfFooter : PdfPageEventHelper
+        {
+            public override void OnEndPage(PdfWriter writer, Document document)
+            {
+                string dateTimeStamp = DateTime.Now.ToString("yyyy-MM-dd hh:mm tt");
+                Font footerFont = FontFactory.GetFont(FontFactory.HELVETICA, 8);
+                PdfPTable footerTable = new PdfPTable(1);
+                footerTable.TotalWidth =
+                    document.PageSize.Width - document.LeftMargin - document.RightMargin;
+                footerTable.DefaultCell.Border = Rectangle.NO_BORDER;
+                footerTable.DefaultCell.HorizontalAlignment = Element.ALIGN_CENTER;
+                footerTable.AddCell(new Phrase($"Printed on: {dateTimeStamp}", footerFont));
+                footerTable.WriteSelectedRows(0,-1,document.LeftMargin,document.BottomMargin - 10,writer.DirectContent);
+            }
+        }
+
+        // [HttpGet("clinic-report-pdf/{clinicId}")]
+        // public IActionResult GenerateClinicReportPdf(long clinicId,[FromQuery] string fromDate,[FromQuery] string toDate)
+        // {
+        //     try
+        //     {
+        //         var parsedFromDate = DateTime.Parse(fromDate);
+        //         var parsedToDate = DateTime.Parse(toDate);
+        //         var clinic = _db
+        //             .Clinics.Include(c => c.Doctor)
+        //             .FirstOrDefault(c => c.Id == clinicId);
+
+        //         if (clinic == null)
+        //         {
+        //             return NotFound("Clinic not found.");
+        //         }
+
+        //         var doctorName = clinic.Doctor?.DisplayName ?? "Unknown Doctor";
+        //         var additionalInfo = clinic.Doctor?.AdditionalInfo ?? "No additional info";
+        //         var clinicName = clinic.Name ?? "Unknown Clinic";
+        //         var monogramImage = clinic.MonogramImage ?? "default-monogram.png";
+        //         var address = clinic.Address ?? "Unknown Address";
+        //         var phoneNumber = clinic.PhoneNumber ?? "Unknown Phone Number";
+
+
+        //         if (!schedules.Any())
+        //         {
+        //             return NotFound("No data found for the specified clinic and date range.");
+        //         }
+
+        //         var groupedSchedules = schedules
+        //             .GroupBy(s => new { s.Id, s.Name })
+        //             .Select(patientGroup => new
+        //             {
+        //                 Patient = patientGroup.Key,
+        //                 Dates = patientGroup.GroupBy(s => s.GivenDate.Date),
+        //             });
+
+        //         using (MemoryStream ms = new MemoryStream())
+        //         {
+        //             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+        //             PdfWriter writer = PdfWriter.GetInstance(document, ms);
+        //             writer.PageEvent = new PdfFooter();
+        //             document.Open();
+        //             PdfPTable upperTable = new PdfPTable(2);
+        //             float[] upperTableWidths = new float[] { 350f, 160f };
+        //             upperTable.HorizontalAlignment = 0;
+        //             upperTable.TotalWidth = 510f;
+        //             upperTable.LockedWidth = true;
+        //             upperTable.SetWidths(upperTableWidths);
+        //             Font boldFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+        //             Font regularFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+        //             Phrase phrase = new Phrase();
+        //             phrase.Add(new Chunk(doctorName + "\n", boldFont));
+        //             phrase.Add(new Chunk(additionalInfo + "\n", regularFont));
+        //             phrase.Add(new Chunk(clinicName + "\n", boldFont));
+        //             phrase.Add(new Chunk(address + "\n", regularFont));
+        //             phrase.Add(new Chunk(phoneNumber, regularFont));
+        //             PdfPCell leftCell = new PdfPCell(phrase)
+        //             {
+        //                 Border = 0,
+        //                 HorizontalAlignment = Element.ALIGN_LEFT,
+        //                 Padding = 5,
+        //             };
+
+        //             upperTable.AddCell(leftCell);
+
+        //             var logoPath = Path.Combine(_host.ContentRootPath, monogramImage);
+        //             PdfPCell imageCell = new PdfPCell(new Phrase(""))
+        //             {
+        //                 Border = 0,
+        //                 FixedHeight = 50f,
+        //                 HorizontalAlignment = Element.ALIGN_RIGHT,
+        //             };
+        //             if (System.IO.File.Exists(logoPath))
+        //             {
+        //                 var img = Image.GetInstance(logoPath);
+        //                 img.ScaleAbsolute(160f, 50f);
+        //                 imageCell = new PdfPCell(img, false)
+        //                 {
+        //                     Border = 0,
+        //                     FixedHeight = 50f,
+        //                     HorizontalAlignment = Element.ALIGN_RIGHT,
+        //                 };
+        //             }
+        //             upperTable.AddCell(imageCell);
+
+        //             document.Add(upperTable);
+
+        //             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+        //             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 9);
+        //             Paragraph item = new Paragraph(
+        //                 "ITEM NAME: BCG",
+        //                 normalFont
+        //             );
+        //             item.Alignment = Element.ALIGN_CENTER;
+        //             document.Add(item);
+
+        //             Paragraph itemtext = new Paragraph(
+        //                 "ITEM REPORT",
+        //                 headerFont
+        //             );
+        //             itemtext.Alignment = Element.ALIGN_CENTER;
+        //             document.Add(itemtext);
+
+        //             Paragraph dateRange = new Paragraph(
+        //                 $"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}",
+        //                 normalFont
+        //             );
+        //             dateRange.Alignment = Element.ALIGN_CENTER;
+        //             dateRange.SpacingAfter = 10f;
+        //             document.Add(dateRange);
+
+        //             PdfPTable table = new PdfPTable(6);
+        //             table.WidthPercentage = 100;
+        //             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f, 2f });
+
+        //             string[] headers ={"Date","Opening Stock","Sold","Purchased","Adjust","Stock In Hand",};
+        //             foreach (string header in headers)
+        //             {
+        //                 var cell = new PdfPCell(new Phrase(header, headerFont))
+        //                 {
+        //                     HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     Padding = 6,
+        //                     BackgroundColor = BaseColor.LightGray,
+        //                 };
+        //                 table.AddCell(cell);
+        //             }
+
+        //             decimal grandTotalConsultationFee = 0;
+
+        //             foreach (var row in reportData)
+        //             {
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.OpeningStock.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Sold.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Purchased.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.Adjust.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //                 table.AddCell(
+        //                     new PdfPCell(new Phrase(row.StockInHand.ToString(), normalFont))
+        //                     {
+        //                         HorizontalAlignment = Element.ALIGN_CENTER,
+        //                     }
+        //                 );
+        //             }
+        //             document.Add(table);
+
+        //             // Paragraph summary = new Paragraph(
+        //             //     $"\nTotal Patients: {groupedSchedules.Count()}"
+        //             //         + $"\nTotal Vaccination Fee: ₹{grandTotalConsultationFee:N2}"
+        //             //         + $"\nTotal Items Price: ₹{schedules.Sum(s => s.InvoicePrice):N2}"
+        //             //         + $"\nGrand Total Cash: ₹{schedules.Sum(s => s.InvoicePrice) + grandTotalConsultationFee:N2}",
+        //             //     headerFont
+        //             // );
+        //             // summary.SpacingBefore = 20f;
+        //             // document.Add(summary);
+
+        //             document.Close();
+        //             return File(
+        //                 ms.ToArray(),
+        //                 "application/pdf",
+        //                 $"ItemReport_{clinicId}_{parsedFromDate:yyyyMMdd}_{parsedToDate:yyyyMMdd}.pdf"
+        //             );
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         return BadRequest($"Error generating PDF: {ex.Message}");
+        //     }
+        // }
+
+        [HttpGet("brand-stock-report-pdf")]
+        public IActionResult GenerateBrandStockReportPdf(
+            [FromQuery] long clinicId,
+            [FromQuery] long brandId,
+            [FromQuery] string fromDate,
+            [FromQuery] string toDate
+        )
+        {
+            try
+            {
+                var parsedFromDate = DateTime.Parse(fromDate);
+                var parsedToDate = DateTime.Parse(toDate);
+
+                // Fetch clinic details
+                var clinic = _db
+                    .Clinics.Include(c => c.Doctor)
+                    .FirstOrDefault(c => c.Id == clinicId);
+                if (clinic == null)
+                {
+                    return NotFound("Clinic not found.");
+                }
+
+                // Fetch brand details
+                var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+                if (brand == null)
+                {
+                    return NotFound("Brand not found.");
+                }
+
+                // Clinic details with null checks
+                var doctorName = clinic.Doctor?.DisplayName ?? "Unknown Doctor";
+                var additionalInfo = clinic.Doctor?.AdditionalInfo ?? "No additional info";
+                var clinicName = clinic.Name ?? "Unknown Clinic";
+                var monogramImage = clinic.MonogramImage ?? "default-monogram.png";
+                var address = clinic.Address ?? "Unknown Address";
+                var phoneNumber = clinic.PhoneNumber ?? "Unknown Phone Number";
+
+                //          var parsedFromDate = DateTime.Parse(fromDate).Date;
+                // var parsedToDate = DateTime.Parse(toDate).Date;
+                var today = DateTime.Today;
+
+                // Get brand
+                // var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+                if (brand == null)
+                    return NotFound("Brand not found.");
+
+                // Get today's inventory
+                var brandAmount = _db.BrandAmounts.FirstOrDefault(b =>
+                    b.BrandId == brandId && b.ClinicId == clinicId
+                );
+
+                if (brandAmount == null)
+                    return NotFound("Brand amount not found.");
+
+                int todaysInventory = brandAmount.Count;
+
+                // Get all schedules from fromDate to today
+                var schedules = _db
+                    .Schedules.Where(s =>
+                        s.BrandId == brandId
+                        && s.GivenDate >= parsedFromDate
+                        && s.GivenDate <= today
+                    )
+                    .ToList();
+
+                var stockPurchases = _db
+                    .Stocks.Join(
+                        _db.Bills,
+                        stock => stock.BillId,
+                        bill => bill.Id,
+                        (stock, bill) => new { stock, bill }
+                    )
+                    .Where(sb =>
+                        sb.stock.BrandId == brandId
+                        && sb.bill.BillDate >= parsedFromDate
+                        && sb.bill.BillDate <= parsedToDate
+                    )
+                    .GroupBy(sb => sb.bill.BillDate.Date)
+                    .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+                var vaccineGroups = schedules
+                    .GroupBy(s => s.GivenDate)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                var stockAdjustments = _db
+                    .AdjustStocks.Where(a =>
+                        a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate
+                    )
+                    .GroupBy(a => a.Date)
+                    .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+                var allDates = Enumerable
+                    .Range(0, (parsedToDate - parsedFromDate).Days + 1)
+                    .Select(offset => parsedFromDate.AddDays(offset))
+                    .ToList();
+
+                var reportData =
+                    new List<(
+                        DateTime Date,
+                        int Inventory,
+                        int VaccinesDone,
+                        int StockPurchased,
+                        int StockAdjusted,
+                        int StockInHand
+                    )>();
+
+                foreach (var date in allDates)
+                {
+                    int vaccinesDoneToday = vaccineGroups.ContainsKey(date)
+                        ? vaccineGroups[date]
+                        : 0;
+                    int stockPurchasedToday = stockPurchases.ContainsKey(date)
+                        ? stockPurchases[date]
+                        : 0;
+                    int stockAdjustedToday = stockAdjustments.ContainsKey(date)
+                        ? stockAdjustments[date]
+                        : 0;
+
+                    int totalFutureVaccines = schedules
+                        .Where(s => s.GivenDate >= date && s.GivenDate <= today)
+                        .Count();
+
+                    int cumulativeStockPurchased = stockPurchases
+                        .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+                        .Sum(kvp => kvp.Value);
+
+                    int cumulativeStockAdjusted = stockAdjustments
+                        .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+                        .Sum(kvp => kvp.Value);
+
+                    int inventory =
+                        todaysInventory
+                        - totalFutureVaccines
+                        - cumulativeStockPurchased
+                        - cumulativeStockAdjusted;
+                    int stockInHand =
+                        todaysInventory
+                        + totalFutureVaccines
+                        + cumulativeStockPurchased
+                        + cumulativeStockAdjusted;
+                    // New logic for stock in hand (up to current date)
+                    int cumulativeVaccinesDone = schedules.Where(s => s.GivenDate <= date).Count();
+
+                    int cumulativePurchased = stockPurchases
+                        .Where(kvp => kvp.Key <= date)
+                        .Sum(kvp => kvp.Value);
+
+                    int cumulativeAdjusted = stockAdjustments
+                        .Where(kvp => kvp.Key <= date)
+                        .Sum(kvp => kvp.Value);
+
+                    // int stockInHand = todaysInventory - cumulativeVaccinesDone + cumulativePurchased + cumulativeAdjusted;
+
+                    reportData.Add(
+                        (
+                            date,
+                            inventory,
+                            vaccinesDoneToday,
+                            stockPurchasedToday,
+                            stockAdjustedToday,
+                            stockInHand
+                        )
+                    );
+                }
+
+                // Generate list of dates
+                // var allDates = Enumerable
+                //     .Range(0, (parsedToDate - parsedFromDate).Days + 1)
+                //     .Select(offset => parsedFromDate.AddDays(offset))
+                //     .ToList();
+
+                // // Fetch report data
+                // var reportData = (
+                //     from date in allDates
+                //     join bill in _db.Bills on date.Date equals bill.BillDate.Date into billGroup
+                //     from bill in billGroup.DefaultIfEmpty()
+                //     join stock in _db.Stocks on bill.Id equals stock.BillId into stockGroup
+                //     from stock in stockGroup.DefaultIfEmpty()
+                //     join brandAmount in _db.BrandAmounts
+                //         on new { BrandId = stock?.BrandId ?? 0, ClinicId = clinicId } equals new
+                //         {
+                //             brandAmount.BrandId,
+                //             brandAmount.ClinicId,
+                //         }
+                //         into brandAmountGroup
+                //     from brandAmount in brandAmountGroup.DefaultIfEmpty()
+                //     join adjust in _db.AdjustStocks
+                //         on stock?.BrandId ?? 0 equals adjust.BrandId
+                //         into adjustGroup
+                //     from adjust in adjustGroup.DefaultIfEmpty()
+                //     join schedule in _db.Schedules
+                //         on stock?.BrandId ?? 0 equals schedule.BrandId
+                //         into scheduleGroup
+                //     from schedule in scheduleGroup.DefaultIfEmpty()
+                //     where stock == null || stock.BrandId == brandId
+                //     group new
+                //     {
+                //         date,
+                //         stock,
+                //         adjust,
+                //         schedule,
+                //         brandAmount,
+                //     } by date.Date into grouped
+                //     select new
+                //     {
+                //         Date = grouped.Key,
+                //         OpeningStock = grouped.Sum(g => g.brandAmount?.Count ?? 0), // Default to 0 if no data
+                //         Sold = grouped.Sum(g => g.schedule != null ? 1 : 0), // Default to 0 if no data
+                //         Adjust = grouped.Sum(g => g.adjust?.Adjustment ?? 0), // Default to 0 if no data
+                //         Inventory = grouped.Sum(g => g.brandAmount?.Count ?? 0)
+                //             - grouped.Sum(g => g.schedule != null ? 1 : 0)
+                //             + grouped.Sum(g => g.adjust?.Adjustment ?? 0),
+                //     }
+                // ).OrderBy(r => r.Date).ToList();
+
+                // if (!reportData.Any())
+                // {
+                //     return NotFound(
+                //         "No data found for the specified clinic, brand, and date range."
+                //     );
+                // }
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+                    PdfWriter writer = PdfWriter.GetInstance(document, ms);
+                    writer.PageEvent = new PdfFooter(); // Custom footer if you have one
+                    document.Open();
+
+                    // Create upper header with clinic info
+                    PdfPTable upperTable = new PdfPTable(2);
+                    float[] upperTableWidths = new float[] { 350f, 160f };
+                    upperTable.HorizontalAlignment = 0;
+                    upperTable.TotalWidth = 510f;
+                    upperTable.LockedWidth = true;
+                    upperTable.SetWidths(upperTableWidths);
+
+                    Font boldFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+                    Font regularFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+                    Phrase phrase = new Phrase();
+                    phrase.Add(new Chunk(doctorName + "\n", boldFont));
+                    phrase.Add(new Chunk(additionalInfo + "\n", regularFont));
+                    phrase.Add(new Chunk(clinicName + "\n", boldFont));
+                    phrase.Add(new Chunk(address + "\n", regularFont));
+                    phrase.Add(new Chunk(phoneNumber, regularFont));
+
+                    PdfPCell leftCell = new PdfPCell(phrase)
+                    {
+                        Border = 0,
+                        HorizontalAlignment = Element.ALIGN_LEFT,
+                        Padding = 5,
+                    };
+                    upperTable.AddCell(leftCell);
+
+                    var imageCell = new PdfPCell(new Phrase(""))
+                    {
+                        Border = 0,
+                        FixedHeight = 50f,
+                        HorizontalAlignment = Element.ALIGN_RIGHT,
+                    };
+
+                    if (!string.IsNullOrEmpty(monogramImage))
+                    {
+                        var logoPath = Path.Combine(_host.ContentRootPath, monogramImage);
+                        if (System.IO.File.Exists(logoPath))
+                        {
+                            var img = Image.GetInstance(logoPath);
+                            img.ScaleAbsolute(160f, 50f);
+                            imageCell = new PdfPCell(img, false)
+                            {
+                                Border = 0,
+                                FixedHeight = 50f,
+                                HorizontalAlignment = Element.ALIGN_RIGHT,
+                            };
+                        }
+                    }
+
+                    upperTable.AddCell(imageCell);
+                    document.Add(upperTable);
+
+                    // Titles
+                    Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+                    Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 9);
+
+                    document.Add(
+                        new Paragraph($"ITEM NAME: {brand?.Name ?? "Unknown"}", normalFont)
+                        {
+                            Alignment = Element.ALIGN_CENTER,
+                        }
+                    );
+
+                    document.Add(
+                        new Paragraph("ITEM REPORT", headerFont)
+                        {
+                            Alignment = Element.ALIGN_CENTER,
+                        }
+                    );
+
+                    document.Add(
+                        new Paragraph(
+                            $"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}",
+                            normalFont
+                        )
+                        {
+                            Alignment = Element.ALIGN_CENTER,
+                            SpacingAfter = 10f,
+                        }
+                    );
+                    PdfPTable table = new PdfPTable(6) { WidthPercentage = 100 };
+                    table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f, 2f });
+
+                    string[] headers =
+                    {
+                        "Date",
+                        "Inventory",
+                        "Vaccines Done",
+                        "Stock Purchased",
+                        "Stock Adjusted",
+                        "Stock In Hand",
+                    };
+                    foreach (var header in headers)
+                    {
+                        table.AddCell(
+                            new PdfPCell(new Phrase(header, headerFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                                BackgroundColor = BaseColor.LightGray,
+                                Padding = 5,
+                            }
+                        );
+                    }
+
+                    foreach (var row in reportData)
+                    {
+                        table.AddCell(
+                            new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                        table.AddCell(
+                            new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                        table.AddCell(
+                            new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                        table.AddCell(
+                            new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                        table.AddCell(
+                            new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont))
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                        table.AddCell(
+                            new PdfPCell(
+                                new Phrase(
+                                    (
+                                        row.Inventory
+                                        + row.VaccinesDone
+                                        + row.StockPurchased
+                                        + row.StockAdjusted
+                                    ).ToString(),
+                                    normalFont
+                                )
+                            )
+                            {
+                                HorizontalAlignment = Element.ALIGN_CENTER,
+                            }
+                        );
+                    }
+
+                    document.Add(table);
+                    document.Close();
+
+                    // // Report Table
+                    // PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
+                    // table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
+
+                    // string[] headers = { "Date", "Opening Stock", "Sold", "Adjust", "Inventory" };
+                    // foreach (var header in headers)
+                    // {
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(header, headerFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //             Padding = 6,
+                    //             BackgroundColor = BaseColor.LightGray,
+                    //         }
+                    //     );
+                    // }
+
+                    // foreach (var row in reportData)
+                    // {
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         }
+                    //     );
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(row.OpeningStock.ToString(), normalFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         }
+                    //     );
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(row.Sold.ToString(), normalFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         }
+                    //     );
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(row.Adjust.ToString(), normalFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         }
+                    //     );
+                    //     table.AddCell(
+                    //         new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont))
+                    //         {
+                    //             HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         }
+                    //     );
+                    // }
+
+                    // // Summary Row
+                    // table.AddCell(
+                    //     new PdfPCell(new Phrase("Total", headerFont))
+                    //     {
+                    //         HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         BackgroundColor = BaseColor.LightGray,
+                    //     }
+                    // );
+                    // table.AddCell(
+                    //     new PdfPCell(
+                    //         new Phrase(reportData.Sum(r => r.OpeningStock).ToString(), headerFont)
+                    //     )
+                    //     {
+                    //         HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         BackgroundColor = BaseColor.LightGray,
+                    //     }
+                    // );
+                    // table.AddCell(
+                    //     new PdfPCell(new Phrase(reportData.Sum(r => r.Sold).ToString(), headerFont))
+                    //     {
+                    //         HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         BackgroundColor = BaseColor.LightGray,
+                    //     }
+                    // );
+                    // table.AddCell(
+                    //     new PdfPCell(
+                    //         new Phrase(reportData.Sum(r => r.Adjust).ToString(), headerFont)
+                    //     )
+                    //     {
+                    //         HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         BackgroundColor = BaseColor.LightGray,
+                    //     }
+                    // );
+                    // table.AddCell(
+                    //     new PdfPCell(
+                    //         new Phrase(reportData.Sum(r => r.Inventory).ToString(), headerFont)
+                    //     )
+                    //     {
+                    //         HorizontalAlignment = Element.ALIGN_CENTER,
+                    //         BackgroundColor = BaseColor.LightGray,
+                    //     }
+                    // );
+
+                    // document.Add(table);
+                    // document.Close();
+
+                    return File(
+                        ms.ToArray(),
+                        "application/pdf",
+                        $"BrandStockReport_Clinic_{clinicId}_Brand_{brandId}_{parsedFromDate:yyyyMMdd}_{parsedToDate:yyyyMMdd}.pdf"
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                // Optional: add logging here
+                return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+            }
+        }
+
+//      [HttpGet("brand-stock-report-pdf1")]
+// public IActionResult GenerateBrandStockReportPdf1(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+//         var today = DateTime.Today;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to today
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= today)
+//             .ToList();
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Vaccines done from this day to today (inclusive)
+//             int totalFutureVaccines = schedules
+//                 .Where(s => s.GivenDate >= date && s.GivenDate <= today)
+//                 .Count();
+
+//             int inventory = todaysInventory - totalFutureVaccines;
+
+//             reportData.Add((date, inventory, vaccinesDoneToday));
+//         }
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(3) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+
+// //     [HttpGet("brand-stock-report-pdf11")]
+// // public IActionResult GenerateBrandStockReportPdf11(
+// //     [FromQuery] long clinicId,
+// //     [FromQuery] long brandId,
+// //     [FromQuery] string fromDate,
+// //     [FromQuery] string toDate
+// // )
+// // {
+// //     try
+// //     {
+// //         var parsedFromDate = DateTime.Parse(fromDate).Date;
+// //         var parsedToDate = DateTime.Parse(toDate).Date;
+// //         var today = DateTime.Today;
+
+// //         // Get brand
+// //         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+// //         if (brand == null)
+// //             return NotFound("Brand not found.");
+
+// //         // Get today's inventory
+// //         var brandAmount = _db.BrandAmounts
+// //             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+// //         if (brandAmount == null)
+// //             return NotFound("Brand amount not found.");
+
+// //         int todaysInventory = brandAmount.Count;
+
+// //         // Get all schedules from fromDate to today
+// //         var schedules = _db.Schedules
+// //             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= today)
+// //             .ToList();
+
+// //         var stockPurchases = _db.Stocks
+// //             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+// //             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+// //             .GroupBy(sb => sb.bill.BillDate.Date)
+// //             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+// //         var vaccineGroups = schedules
+// //             .GroupBy(s => s.GivenDate)
+// //             .ToDictionary(g => g.Key, g => g.Count());
+
+// //         var stockAdjustments = _db.AdjustStocks
+// //             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+// //             .GroupBy(a => a.Date)
+// //             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+// //         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+// //             .Select(offset => parsedFromDate.AddDays(offset))
+// //             .ToList();
+
+// //         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted)>();
+
+// //         foreach (var date in allDates)
+// //         {
+// //             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+// //             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+// //             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+// //             int totalFutureVaccines = schedules
+// //                 .Where(s => s.GivenDate >= date && s.GivenDate <= today)
+// //                 .Count();
+
+// //             int cumulativeStockPurchased = stockPurchases
+// //                 .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+// //                 .Sum(kvp => kvp.Value);
+
+// //             int cumulativeStockAdjusted = stockAdjustments
+// //                 .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+// //                 .Sum(kvp => kvp.Value);
+
+// //             int inventory = todaysInventory - totalFutureVaccines + cumulativeStockPurchased + cumulativeStockAdjusted;
+
+// //             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday));
+// //         }
+
+// //         // Generate PDF
+// //         using (var ms = new MemoryStream())
+// //         {
+// //             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+// //             PdfWriter.GetInstance(document, ms);
+// //             document.Open();
+
+// //             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+// //             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+// //             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+// //             {
+// //                 Alignment = Element.ALIGN_CENTER,
+// //                 SpacingAfter = 10f
+// //             });
+
+// //             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+// //             document.Add(new Paragraph($"Inventory as of Today ({today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+// //             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+// //             document.Add(new Paragraph("\n", normalFont));
+
+// //             PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
+// //             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
+
+// //             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted" };
+// //             foreach (var header in headers)
+// //             {
+// //                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+// //                 {
+// //                     HorizontalAlignment = Element.ALIGN_CENTER,
+// //                     BackgroundColor = BaseColor.LightGray,
+// //                     Padding = 5
+// //                 });
+// //             }
+
+// //             foreach (var row in reportData)
+// //             {
+// //                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+// //                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+// //                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+// //                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+// //                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+// //             }
+
+// //             document.Add(table);
+// //             document.Close();
+
+// //             return File(ms.ToArray(), "application/pdf",
+// //                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+// //         }
+// //     }
+// //     catch (Exception ex)
+// //     {
+// //         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+// //     }
+// // }
+
+// [HttpGet("brand-stock-report-pdf11")]
+// public IActionResult GenerateBrandStockReportPdf11(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+//         var today = DateTime.Today;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to today
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= today)
+//             .ToList();
+
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var stockAdjustments = _db.AdjustStocks
+//             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+//             .GroupBy(a => a.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted, int StockInHand)>();
+
+//         foreach (var date in allDates)
+//         {
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+//             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+//             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+//             int totalFutureVaccines = schedules
+//                 .Where(s => s.GivenDate >= date && s.GivenDate <= today)
+//                 .Count();
+
+//             int cumulativeStockPurchased = stockPurchases
+//                 .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+//                 .Sum(kvp => kvp.Value);
+
+//             int cumulativeStockAdjusted = stockAdjustments
+//                 .Where(kvp => kvp.Key >= date && kvp.Key <= today)
+//                 .Sum(kvp => kvp.Value);
+
+//             int inventory = todaysInventory - totalFutureVaccines - cumulativeStockPurchased - cumulativeStockAdjusted;
+//             int stockInHand = todaysInventory + totalFutureVaccines + cumulativeStockPurchased + cumulativeStockAdjusted;
+//             // New logic for stock in hand (up to current date)
+//             int cumulativeVaccinesDone = schedules
+//                 .Where(s => s.GivenDate <= date)
+//                 .Count();
+
+//             int cumulativePurchased = stockPurchases
+//                 .Where(kvp => kvp.Key <= date)
+//                 .Sum(kvp => kvp.Value);
+
+//             int cumulativeAdjusted = stockAdjustments
+//                 .Where(kvp => kvp.Key <= date)
+//                 .Sum(kvp => kvp.Value);
+
+//             // int stockInHand = todaysInventory - cumulativeVaccinesDone + cumulativePurchased + cumulativeAdjusted;
+
+//             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday, stockInHand));
+//         }
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4.Rotate(), 25, 25, 30, 30); // Rotated for more width
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(6) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted", "Stock In Hand" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase((row.Inventory + row.VaccinesDone + row.StockPurchased + row.StockAdjusted).ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+
+
+// [HttpGet("brand-stock-report-pdf12")]
+// public IActionResult GenerateBrandStockReportPdf12(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+//         var today = DateTime.Today;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to today
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= today)
+//             .ToList();
+
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Vaccines done from this day to today (inclusive)
+//             int totalFutureVaccines = schedules
+//                 .Where(s => s.GivenDate >= date && s.GivenDate <= today)
+//                 .Count();
+
+//             int inventory = todaysInventory - totalFutureVaccines;
+
+//             reportData.Add((date, inventory, vaccinesDoneToday));
+//         }
+
+//         // Sort reportData in reverse order by date
+//         reportData = reportData.OrderByDescending(r => r.Date).ToList();
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(3) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+// [HttpGet("brand-stock-report-pdf123")]
+// public IActionResult GenerateBrandStockReportPdf123(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to toDate
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= parsedToDate)
+//             .ToList();
+
+//         // Get all stock purchases based on BillDate
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         // Get all stock adjustments from fromDate to toDate
+//         var stockAdjustments = _db.AdjustStocks
+//             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+//             .GroupBy(a => a.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Stock purchased on this day
+//             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+
+//             // Stock adjusted on this day
+//             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+//             // Inventory calculation
+//             int inventory = todaysInventory - schedules.Count(s => s.GivenDate <= date);
+
+//             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday));
+//         }
+
+//         // Sort reportData in reverse order by date
+//         reportData = reportData.OrderByDescending(r => r.Date).ToList();
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({DateTime.Today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+// [HttpGet("brand-stock-report-pdf1234")]
+// public IActionResult GenerateBrandStockReportPdf1234(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to toDate
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= parsedToDate)
+//             .ToList();
+
+//         // Get all stock purchases based on BillDate
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         // Get all stock adjustments from fromDate to toDate
+//         var stockAdjustments = _db.AdjustStocks
+//             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+//             .GroupBy(a => a.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Stock purchased on this day
+//             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+
+//             // Stock adjusted on this day
+//             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+//             // Inventory calculation
+//             int inventory = todaysInventory - schedules.Count(s => s.GivenDate <= date);
+
+//             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday));
+//         }
+
+//         // Sort reportData in reverse order by date
+//         reportData = reportData.OrderByDescending(r => r.Date).ToList();
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({DateTime.Today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+// [HttpGet("brand-stock-report-pdf12345")]
+// public IActionResult GenerateBrandStockReportPdf12345(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to toDate
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= parsedToDate)
+//             .ToList();
+
+//         // Get all stock purchases based on BillDate
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         // Get all stock adjustments from fromDate to toDate
+//         var stockAdjustments = _db.AdjustStocks
+//             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+//             .GroupBy(a => a.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         // reportData = reportData.OrderByDescending(r => r.Inventory).ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Stock purchased on this day
+//             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+
+//             // Stock adjusted on this day
+//             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+//             // Inventory calculation
+//             int inventory = todaysInventory - schedules.Count(s => s.GivenDate <= date);
+
+//             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday));
+//         }
+
+//         // Sort reportData by Inventory in descending order
+//         reportData = reportData.OrderByDescending(r => r.Inventory).ToList();
+//         // reportData = reportData.OrderByDescending(r => r.Date).ToList();
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({DateTime.Today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(5) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
+
+// [HttpGet("brand-stock-report-pdf123456")]
+// public IActionResult GenerateBrandStockReportPdf123456(
+//     [FromQuery] long clinicId,
+//     [FromQuery] long brandId,
+//     [FromQuery] string fromDate,
+//     [FromQuery] string toDate
+// )
+// {
+//     try
+//     {
+//         var parsedFromDate = DateTime.Parse(fromDate).Date;
+//         var parsedToDate = DateTime.Parse(toDate).Date;
+
+//         // Get brand
+//         var brand = _db.Brands.FirstOrDefault(b => b.Id == brandId);
+//         if (brand == null)
+//             return NotFound("Brand not found.");
+
+//         // Get today's inventory
+//         var brandAmount = _db.BrandAmounts
+//             .FirstOrDefault(b => b.BrandId == brandId && b.ClinicId == clinicId);
+
+//         if (brandAmount == null)
+//             return NotFound("Brand amount not found.");
+
+//         int todaysInventory = brandAmount.Count;
+
+//         // Get all schedules from fromDate to toDate
+//         var schedules = _db.Schedules
+//             .Where(s => s.BrandId == brandId && s.GivenDate >= parsedFromDate && s.GivenDate <= parsedToDate)
+//             .ToList();
+
+//         // Get all stock purchases based on BillDate
+//         var stockPurchases = _db.Stocks
+//             .Join(_db.Bills, stock => stock.BillId, bill => bill.Id, (stock, bill) => new { stock, bill })
+//             .Where(sb => sb.stock.BrandId == brandId && sb.bill.BillDate >= parsedFromDate && sb.bill.BillDate <= parsedToDate)
+//             .GroupBy(sb => sb.bill.BillDate.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(sb => sb.stock.Quantity));
+
+//         // Get all stock adjustments from fromDate to toDate
+//         var stockAdjustments = _db.AdjustStocks
+//             .Where(a => a.BrandId == brandId && a.Date >= parsedFromDate && a.Date <= parsedToDate)
+//             .GroupBy(a => a.Date)
+//             .ToDictionary(g => g.Key, g => g.Sum(a => a.Adjustment));
+
+//         // Create grouped vaccine count
+//         var vaccineGroups = schedules
+//             .GroupBy(s => s.GivenDate)
+//             .ToDictionary(g => g.Key, g => g.Count());
+
+//         var allDates = Enumerable.Range(0, (parsedToDate - parsedFromDate).Days + 1)
+//             .Select(offset => parsedFromDate.AddDays(offset))
+//             .ToList();
+
+//         var reportData = new List<(DateTime Date, int Inventory, int VaccinesDone, int StockPurchased, int StockAdjusted, int StockInHand)>();
+
+//         foreach (var date in allDates)
+//         {
+//             // Vaccines done on this day
+//             int vaccinesDoneToday = vaccineGroups.ContainsKey(date) ? vaccineGroups[date] : 0;
+
+//             // Stock purchased on this day
+//             int stockPurchasedToday = stockPurchases.ContainsKey(date) ? stockPurchases[date] : 0;
+
+//             // Stock adjusted on this day
+//             int stockAdjustedToday = stockAdjustments.ContainsKey(date) ? stockAdjustments[date] : 0;
+
+//             // Inventory calculation
+//             int inventory = todaysInventory - schedules.Count(s => s.GivenDate <= date);
+
+//             // Stock in hand calculation
+//             int stockInHand = inventory + stockPurchasedToday + stockAdjustedToday;
+
+//             reportData.Add((date, inventory, vaccinesDoneToday, stockPurchasedToday, stockAdjustedToday, stockInHand));
+//         }
+
+//         // Sort reportData in reverse order by date
+//         reportData = reportData.OrderByDescending(r => r.Date).ToList();
+
+//         // Generate PDF
+//         using (var ms = new MemoryStream())
+//         {
+//             Document document = new Document(PageSize.A4, 25, 25, 30, 30);
+//             PdfWriter.GetInstance(document, ms);
+//             document.Open();
+
+//             Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
+//             Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+
+//             document.Add(new Paragraph("BRAND DAILY STOCK REPORT", headerFont)
+//             {
+//                 Alignment = Element.ALIGN_CENTER,
+//                 SpacingAfter = 10f
+//             });
+
+//             document.Add(new Paragraph($"Brand Name: {brand.Name}", normalFont));
+//             document.Add(new Paragraph($"Inventory as of Today ({DateTime.Today:dd-MM-yyyy}): {todaysInventory}", normalFont));
+//             document.Add(new Paragraph($"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}", normalFont));
+//             document.Add(new Paragraph("\n", normalFont));
+
+//             PdfPTable table = new PdfPTable(6) { WidthPercentage = 100 };
+//             table.SetWidths(new float[] { 2f, 2f, 2f, 2f, 2f, 2f });
+
+//             string[] headers = { "Date", "Inventory", "Vaccines Done", "Stock Purchased", "Stock Adjusted", "Stock In Hand" };
+//             foreach (var header in headers)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(header, headerFont))
+//                 {
+//                     HorizontalAlignment = Element.ALIGN_CENTER,
+//                     BackgroundColor = BaseColor.LightGray,
+//                     Padding = 5
+//                 });
+//             }
+
+//             foreach (var row in reportData)
+//             {
+//                 table.AddCell(new PdfPCell(new Phrase(row.Date.ToString("dd-MM-yyyy"), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.Inventory.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.VaccinesDone.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockPurchased.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockAdjusted.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//                 table.AddCell(new PdfPCell(new Phrase(row.StockInHand.ToString(), normalFont)) { HorizontalAlignment = Element.ALIGN_CENTER });
+//             }
+
+//             document.Add(table);
+//             document.Close();
+
+//             return File(ms.ToArray(), "application/pdf",
+//                 $"BrandStock_{brand.Name}_{parsedFromDate:yyyyMMdd}_to_{parsedToDate:yyyyMMdd}.pdf");
+//         }
+//     }
+//     catch (Exception ex)
+//     {
+//         return BadRequest($"Error generating PDF: {ex.Message}\n{ex.StackTrace}");
+//     }
+// }
     }
 }

--- a/Controllers/ScheduleController.cs
+++ b/Controllers/ScheduleController.cs
@@ -1765,11 +1765,11 @@ namespace VaccineAPI.Controllers
             }
         }
 
-        public class PdfFooter : PdfPageEventHelper
+         public class PdfFooter : PdfPageEventHelper
         {
             public override void OnEndPage(PdfWriter writer, Document document)
             {
-                string dateTimeStamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                string dateTimeStamp = DateTime.Now.ToString("yyyy-MM-dd hh:mm tt");
                 Font footerFont = FontFactory.GetFont(FontFactory.HELVETICA, 8);
                 PdfPTable footerTable = new PdfPTable(1);
                 footerTable.TotalWidth =document.PageSize.Width - document.LeftMargin - document.RightMargin;
@@ -1877,17 +1877,23 @@ namespace VaccineAPI.Controllers
                     upperTable.TotalWidth = 510f;
                     upperTable.LockedWidth = true;
                     upperTable.SetWidths(upperTableWidths);
-                    PdfPCell leftCell = new PdfPCell(
-                        new Phrase(
-                            $"{doctorName}\n{additionalInfo}\n{clinicName}\n{address}\n{phoneNumber}",
-                            FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10)
-                        )
-                    )
+                    Font boldFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
+                    Font regularFont = FontFactory.GetFont(FontFactory.HELVETICA, 10);
+                    Phrase phrase = new Phrase();
+                    phrase.Add(new Chunk(doctorName + "\n", boldFont));
+                    phrase.Add(new Chunk(additionalInfo + "\n", regularFont));
+                    phrase.Add(new Chunk(clinicName + "\n", boldFont));
+                    phrase.Add(new Chunk(address + "\n", regularFont));
+                    phrase.Add(new Chunk(phoneNumber, regularFont));
+
+                    // Create the cell
+                    PdfPCell leftCell = new PdfPCell(phrase)
                     {
                         Border = 0,
                         HorizontalAlignment = Element.ALIGN_LEFT,
                         Padding = 5,
                     };
+
                     upperTable.AddCell(leftCell);
 
                     var logoPath = Path.Combine(_host.ContentRootPath, monogramImage);
@@ -1915,12 +1921,19 @@ namespace VaccineAPI.Controllers
                     Font headerFont = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 10);
                     Font normalFont = FontFactory.GetFont(FontFactory.HELVETICA, 9);
 
+                    Paragraph titletext = new Paragraph(
+                        $"Sales Report",
+                        headerFont
+                    );
+                    titletext.Alignment = Element.ALIGN_CENTER;
+                    document.Add(titletext);
+
                     Paragraph dateRange = new Paragraph(
                         $"Date Range: {parsedFromDate:dd-MM-yyyy} to {parsedToDate:dd-MM-yyyy}",
                         normalFont
                     );
                     dateRange.Alignment = Element.ALIGN_CENTER;
-                    dateRange.SpacingAfter = 20f;
+                    dateRange.SpacingAfter = 10f;
                     document.Add(dateRange);
 
                     PdfPTable table = new PdfPTable(6);
@@ -2081,7 +2094,7 @@ namespace VaccineAPI.Controllers
                     return File(
                         ms.ToArray(),
                         "application/pdf",
-                        $"ClinicReport_{clinicId}_{parsedFromDate:yyyyMMdd}_{parsedToDate:yyyyMMdd}.pdf"
+                        $"SalesReport_{clinicId}_{parsedFromDate:yyyyMMdd}_{parsedToDate:yyyyMMdd}.pdf"
                     );
                 }
             }


### PR DESCRIPTION
- Updated date format in PdfFooter to use 12-hour clock with AM/PM.
- Improved the construction of the left cell in the upper table by using Phrase and Chunk for better formatting.
- Added a centered title "Sales Report" to the document.
- Adjusted spacing after the date range paragraph.
- Renamed the output PDF file to reflect "SalesReport" instead of "ClinicReport".